### PR TITLE
[PaddlePaddle Hackathon] add image augment algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,16 @@ mask = mean(masks)
 |----------------|:-------------------------:|:---------------------------------:|
 | HorizontalFlip | -                         | -                                 |
 | VerticalFlip   | -                         | -                                 |
+| HorizontalShift| shifts                    | List\[float]                      |
+| VerticalShift  | shifts                    | List\[float]                      |
 | Rotate90       | angles                    | List\[0, 90, 180, 270]            |
 | Scale          | scales<br>interpolation   | List\[float]<br>"nearest"/"linear"|
 | Resize         | sizes<br>original_size<br>interpolation   | List\[Tuple\[int, int]]<br>Tuple\[int,int]<br>"nearest"/"linear"|
 | Add            | values                    | List\[float]                      |
 | Multiply       | factors                   | List\[float]                      |
 | FiveCrops      | crop_height<br>crop_width | int<br>int                        |
+| AdjustContrast | factors                   | List\[float]                      |
+| AdjustBrightness|factors                   | List\[float]                      |
  
 ## Aliases (Combos)
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ mask = mean(masks)
 | FiveCrops      | crop_height<br>crop_width | int<br>int                        |
 | AdjustContrast | factors                   | List\[float]                      |
 | AdjustBrightness|factors                   | List\[float]                      |
+| AverageBlur    | kernel_sizes              | List\[Union\[Tuple\[int, int], int]] |
+| GaussianBlur   | kernel_sizes<br>sigma     | List\[Union\[Tuple\[int, int], int]]<br>Optional\[Union\[Tuple\[float, float], float]]|
+| Sharpen        | kernel_sizes              | List[int]                         |
  
 ## Aliases (Combos)
 

--- a/patta/__init__.py
+++ b/patta/__init__.py
@@ -18,6 +18,9 @@ from .transforms import (
     Resize,
     AdjustContrast,
     AdjustBrightness,
+    AverageBlur,
+    GaussianBlur,
+    Sharpen,
 )
 
 from . import aliases

--- a/patta/__init__.py
+++ b/patta/__init__.py
@@ -1,12 +1,23 @@
 from .wrappers import (
     SegmentationTTAWrapper,
     ClassificationTTAWrapper,
-    KeypointsTTAWrapper
+    KeypointsTTAWrapper,
 )
 from .base import Compose
 
 from .transforms import (
-    HorizontalFlip, VerticalFlip, Rotate90, Scale, Add, Multiply, FiveCrops, Resize
+    HorizontalFlip,
+    VerticalFlip,
+    HorizontalShift,
+    VerticalShift,
+    Rotate90,
+    Scale,
+    Add,
+    Multiply,
+    FiveCrops,
+    Resize,
+    AdjustContrast,
+    AdjustBrightness,
 )
 
 from . import aliases

--- a/patta/functional.py
+++ b/patta/functional.py
@@ -1,7 +1,9 @@
+from typing import Optional, Tuple, Union
+
+import cv2
+import numpy as np
 import paddle
 import paddle.nn.functional as F
-import numpy as np
-import cv2
 
 
 def rot90(x, k=1):
@@ -64,9 +66,7 @@ def scale(x, scale_factor, interpolation="nearest", align_corners=False):
     h, w = x.shape[2:]
     new_h = int(h * scale_factor)
     new_w = int(w * scale_factor)
-    return F.interpolate(
-        x, size=(new_h, new_w), mode=interpolation, align_corners=align_corners
-    )
+    return F.interpolate(x, size=(new_h, new_w), mode=interpolation, align_corners=align_corners)
 
 
 def resize(x, size, interpolation="nearest", align_corners=False):
@@ -145,6 +145,79 @@ def adjust_brightness(x, brightness_factor: float=1.):
     x = cv2.LUT(x, table)
     x = x.astype(np.float32)
     return paddle.to_tensor(x)
+
+def filter2d(x, kernel):
+    """applies an arbitrary linear filter to an image"""
+    C = x.shape[1]
+    kernel = kernel.reshape((1, 1, *kernel.shape))
+    kernel = paddle.concat([kernel for _ in range(C)], axis=0)
+    return F.conv2d(x, kernel, stride=1, padding="same", groups=C)
+
+
+def average_blur(x, kernel_size: Union[Tuple[int, int], int] = 3):
+    """smooths the input image"""
+    cv2.blur
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if kernel_size == (1, 1):
+        return x
+    assert (
+        kernel_size[0] > 0 and kernel_size[1] > 0 and kernel_size[0] % 2 == 1 and kernel_size[1] % 2 == 1
+    ), "kernel_size both must be positive and odd"
+    kernel = np.ones(kernel_size[0] * kernel_size[1], dtype=np.float32)
+    kernel = kernel / (kernel_size[0] * kernel_size[1])
+    kernel = kernel.reshape((kernel_size[1], kernel_size[0]))
+    assert kernel.shape == (kernel_size[1], kernel_size[0])
+    kernel = paddle.to_tensor(kernel)
+    return filter2d(x, kernel)
+
+
+def gaussian_blur(
+    x,
+    kernel_size: Union[Tuple[int, int], int] = 3,
+    sigma: Optional[Union[Tuple[float, float], float]] = None
+):
+    """smooths the input image with the specified Gaussian kernel"""
+    cv2.GaussianBlur
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if kernel_size == (1, 1):
+        return x
+    if sigma is None:
+        sigma = (kernel_size[0] - 1) / 4.0
+    if isinstance(sigma, (int, float)):
+        sigma = (sigma, sigma)
+    assert kernel_size[0] > 0 and kernel_size[1] > 0 and kernel_size[0] % 2 == 1 and \
+           kernel_size[1] % 2 == 1, "kernel_size both must be positive and odd"
+    kernel_x = cv2.getGaussianKernel(kernel_size[0], sigma[0])
+    kernel_y = cv2.getGaussianKernel(kernel_size[1], sigma[1])
+    kernel = kernel_y @ kernel_x.transpose()
+    kernel = kernel.astype(np.float32)
+    assert kernel.shape == (kernel_size[1], kernel_size[0])
+    kernel = paddle.to_tensor(kernel)
+    return filter2d(x, kernel)
+
+
+def sharpen(x, kernel_size: int = 3):
+    """sharpen the input image"""
+    if kernel_size == 1:
+        return x
+    assert kernel_size > 0 and kernel_size % 2 == 1, "kernel_size both must be positive and odd"
+    kernel = get_laplacian_kernel(kernel_size).astype(np.float32)
+    kernel = kernel.astype(np.float32)
+    kernel = paddle.to_tensor(kernel)
+    x_laplacian = filter2d(x, kernel)
+    x = x - x_laplacian
+    x = x.clip(0, 255)
+    return x
+
+
+def get_laplacian_kernel(kernel_size):
+    assert kernel_size > 0 and kernel_size % 2 == 1, "kernel_size both must be positive and odd"
+    kernel = np.ones((kernel_size, kernel_size))
+    mid = kernel_size // 2
+    kernel[mid, mid] = 1 - kernel_size ** 2
+    return kernel
 
 
 def _disassemble_keypoints(keypoints):

--- a/patta/transforms.py
+++ b/patta/transforms.py
@@ -354,3 +354,71 @@ class AdjustBrightness(ImageOnlyTransform):
             return F.adjust_brightness(image, factor)
         return image
 
+
+class AverageBlur(ImageOnlyTransform):
+    """Apply average blur to the input image
+
+    Args:
+        kernel_sizes (List[Union[Tuple[int, int], int]]): kernel size of average blur
+    """
+
+    identity_param = 1
+
+    def __init__(
+        self,
+        kernel_sizes: List[Union[Tuple[int, int], int]],
+    ):
+        if self.identity_param not in kernel_sizes:
+            kernel_sizes = [self.identity_param] + list(kernel_sizes)
+        super().__init__("kernel_size", kernel_sizes)
+
+    def apply_aug_image(self, image, kernel_size, **kwargs):
+        if kernel_size == self.identity_param:
+            return image
+        return F.average_blur(image, kernel_size)
+
+
+class GaussianBlur(ImageOnlyTransform):
+    """Apply gaussian blur to the input image
+
+    Args:
+        kernel_sizes (List[Union[Tuple[int, int], int]]): kernel size of gaussian blur
+        sigma (Optional[Union[Tuple[float, float], float]]): gaussian kernel standard deviation
+    """
+    
+    identity_param = 1
+
+    def __init__(
+        self,
+        kernel_sizes: List[Union[Tuple[int, int], int]],
+        sigma: Optional[Union[Tuple[float, float], float]] = None
+    ):
+        if self.identity_param not in kernel_sizes:
+            kernel_sizes = [self.identity_param] + list(kernel_sizes)
+        self.sigma = sigma
+        super().__init__("kernel_size", kernel_sizes)
+
+    def apply_aug_image(self, image, kernel_size, **kwargs):
+        if kernel_size == self.identity_param:
+            return image
+        return F.gaussian_blur(image, kernel_size, self.sigma)
+
+
+class Sharpen(ImageOnlyTransform):
+    """Apply sharpen to the input image
+
+    Args:
+        kernel_sizes (List[int]): kernel size of sharpen
+    """
+
+    identity_param = 1
+
+    def __init__(self, kernel_sizes: List[int]):
+        if self.identity_param not in kernel_sizes:
+            kernel_sizes = [self.identity_param] + list(kernel_sizes)
+        super().__init__("kernel_size", kernel_sizes)
+
+    def apply_aug_image(self, image, kernel_size, **kwargs):
+        if kernel_size == self.identity_param:
+            return image
+        return F.sharpen(image, kernel_size)

--- a/patta/transforms.py
+++ b/patta/transforms.py
@@ -58,6 +58,54 @@ class VerticalFlip(DualTransform):
         return keypoints
 
 
+class HorizontalShift(DualTransform):
+    """Shift images horizontally (left->right)"""
+
+    identity_param = 0
+
+    def __init__(self, shifts: List[float]):
+        if self.identity_param not in shifts:
+            shifts = [self.identity_param] + list(shifts)
+        super().__init__("shifts", shifts)
+
+    def apply_aug_image(self, image, shifts=0, **kwargs):
+        image = F.hshift(image, shifts)
+        return image
+
+    def apply_deaug_mask(self, mask, shifts=0, **kwargs):
+        return self.apply_aug_image(mask, -shifts)
+
+    def apply_deaug_label(self, label, shifts=0, **kwargs):
+        return label
+
+    def apply_deaug_keypoints(self, keypoints, shifts=0, **kwargs):
+        return F.keypoints_hshift(keypoints, -shifts)
+
+
+class VerticalShift(DualTransform):
+    """Shift images vertically (up->down)"""
+
+    identity_param = 0
+
+    def __init__(self, shifts: List[float]):
+        if self.identity_param not in shifts:
+            shifts = [self.identity_param] + list(shifts)
+        super().__init__("shifts", shifts)
+
+    def apply_aug_image(self, image, shifts=0, **kwargs):
+        image = F.vshift(image, shifts)
+        return image
+
+    def apply_deaug_mask(self, mask, shifts=0, **kwargs):
+        return self.apply_aug_image(mask, -shifts)
+
+    def apply_deaug_label(self, label, shifts=0, **kwargs):
+        return label
+
+    def apply_deaug_keypoints(self, keypoints, shifts=0, **kwargs):
+        return F.keypoints_vshift(keypoints, -shifts)
+
+
 class Rotate90(DualTransform):
     """Rotate images 0/90/180/270 degrees
 
@@ -263,3 +311,46 @@ class FiveCrops(ImageOnlyTransform):
 
     def apply_deaug_keypoints(self, keypoints, **kwargs):
         raise ValueError("`FiveCrop` augmentation is not suitable for keypoints!")
+
+
+class AdjustContrast(ImageOnlyTransform):
+    """Adjusts contrast of an Image.
+
+    Args:
+        factors (List[float]): How much to adjust the contrast.
+    """
+
+    identity_param = 1.
+
+    def __init__(self, factors: List[float]):
+
+        if self.identity_param not in factors:
+            factors = [self.identity_param] + list(factors)
+        super().__init__("factor", factors)
+
+    def apply_aug_image(self, image, factor=1., **kwargs):
+        if factor != self.identity_param:
+            return F.adjust_contrast(image, factor)
+        return image
+
+
+class AdjustBrightness(ImageOnlyTransform):
+    """Adjusts brightness of an Image.
+
+    Args:
+        factors (List[float]): How much to adjust the brightness.
+    """
+
+    identity_param = 1.
+    
+    def __init__(self, factors: List[float]):
+
+        if self.identity_param not in factors:
+            factors = [self.identity_param] + list(factors)
+        super().__init__("factor", factors)
+
+    def apply_aug_image(self, image, factor=1., **kwargs):
+        if factor != self.identity_param:
+            return F.adjust_brightness(image, factor)
+        return image
+

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,6 +1,6 @@
-import pytest
 import paddle
 import patta as tta
+import pytest
 
 
 @pytest.mark.parametrize(
@@ -8,6 +8,8 @@ import patta as tta
     [
         tta.HorizontalFlip(),
         tta.VerticalFlip(),
+        tta.HorizontalShift(shifts=[0.1, 0.2, 0.4]),
+        tta.VerticalShift(shifts=[0.1, 0.2, 0.4]),
         tta.Rotate90(angles=[0, 90, 180, 270]),
         tta.Scale(scales=[1, 2, 4], interpolation="nearest"),
         tta.Resize(sizes=[(4, 5), (8, 10)], original_size=(4, 5), interpolation="nearest"),
@@ -26,12 +28,16 @@ def test_aug_deaug_mask(transform):
     [
         tta.HorizontalFlip(),
         tta.VerticalFlip(),
+        tta.HorizontalShift(shifts=[0.1, 0.2, 0.4]),
+        tta.VerticalShift(shifts=[0.1, 0.2, 0.4]),
         tta.Rotate90(angles=[0, 90, 180, 270]),
         tta.Scale(scales=[1, 2, 4], interpolation="nearest"),
         tta.Add(values=[-1, 0, 1, 2]),
         tta.Multiply(factors=[-1, 0, 1, 2]),
         tta.FiveCrops(crop_height=3, crop_width=5),
         tta.Resize(sizes=[(4, 5), (8, 10), (2, 2)], interpolation="nearest"),
+        tta.AdjustBrightness(factors=[0.5, 1.0, 1.5]),
+        tta.AdjustContrast(factors=[0.5, 1.0, 1.5]),
     ],
 )
 def test_label_is_same(transform):
@@ -56,9 +62,13 @@ def test_flip_keypoints(transform):
 
 @pytest.mark.parametrize(
     "transform",
-    [tta.Rotate90(angles=[0, 90, 180, 270])],
+    [
+        tta.Rotate90(angles=[0, 90, 180, 270]),
+        tta.HorizontalShift(shifts=[0.1, 0.2, 0.4]),
+        tta.VerticalShift(shifts=[0.1, 0.2, 0.4]),
+    ],
 )
-def test_rotate90_keypoints(transform):
+def test_rotate90_and_shift_keypoints(transform):
     keypoints = paddle.to_tensor([[0.1, 0.1], [0.1, 0.9], [0.9, 0.1], [0.9, 0.9], [0.4, 0.3]])
     for p in transform.params:
         aug = transform.apply_deaug_keypoints(keypoints.detach().clone(), **{transform.pname: p})
@@ -119,3 +129,67 @@ def test_resize_transform():
     for i, p in enumerate(transform.params):
         aug = transform.apply_aug_image(a, **{transform.pname: p})
         assert paddle.allclose(aug.reshape((aug.shape[-2], aug.shape[-1])), paddle.to_tensor(output[i], paddle.float32))
+
+
+def test_adjust_brightness_transform():
+    transform = tta.AdjustBrightness(factors=[0.5, 1.5])
+    a = paddle.arange(25).reshape((1, 1, 5, 5)).astype(paddle.float32)
+    a = paddle.concat([a, a, a], axis=1)
+    output = [
+        [
+            [0, 1, 2, 3, 4],
+            [5, 6, 7, 8, 9],
+            [10, 11, 12, 13, 14],
+            [15, 16, 17, 18, 19],
+            [20, 21, 22, 23, 24],
+        ],
+        [
+            [0, 0, 1, 1, 2],
+            [2, 3, 3, 4, 4],
+            [5, 5, 6, 6, 7],
+            [7, 8, 8, 9, 9],
+            [10, 10, 11, 11, 12],
+        ],
+        [
+            [0, 1, 3, 4, 6],
+            [7, 9, 10, 12, 13],
+            [15, 16, 18, 19, 21],
+            [22, 24, 25, 27, 28],
+            [30, 31, 33, 34, 36],
+        ],
+    ]
+    for i, p in enumerate(transform.params):
+        aug = transform.apply_aug_image(a, **{transform.pname: p})
+        assert paddle.allclose(aug[0, 0], paddle.to_tensor(output[i], paddle.float32))
+
+
+def test_adjust_contrast_transform():
+    transform = tta.AdjustContrast(factors=[0.5, 1.2])
+    a = paddle.arange(25).reshape((1, 1, 5, 5)).astype(paddle.float32)
+    a = paddle.concat([a, a, a], axis=1)
+    output = [
+        [
+            [0, 1, 2, 3, 4],
+            [5, 6, 7, 8, 9],
+            [10, 11, 12, 13, 14],
+            [15, 16, 17, 18, 19],
+            [20, 21, 22, 23, 24],
+        ],
+        [
+            [37, 37, 38, 38, 39],
+            [39, 40, 40, 41, 41],
+            [42, 42, 43, 43, 44],
+            [44, 45, 45, 46, 46],
+            [47, 47, 48, 48, 49],
+        ],
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 2],
+            [3, 4, 5, 6, 8],
+            [9, 10, 11, 12, 14],
+        ],
+    ]
+    for i, p in enumerate(transform.params):
+        aug = transform.apply_aug_image(a, **{transform.pname: p})
+        assert paddle.allclose(aug[0, 0], paddle.to_tensor(output[i], paddle.float32))


### PR DESCRIPTION
- Task: https://github.com/AgentMaker/PaTTA/issues/5
- Description: 新增不低于5个图像方向的数据增强算法，并且这些算法能够略微、显著提升推理成绩，以提升 PaTTA 可用性

---

- [x] 算法 * 7
   - HorizontalShift 水平平移（DualTransform）
   - VerticalShift 竖直平移（DualTransform）
   - AdjustContrast 调节图片对比度（ImageOnlyTransform）
   - AdjustBrightness 调节图片亮度（ImageOnlyTransform）
   - AverageBlur 均值滤波（ImageOnlyTransform）
   - GaussianBlur 高斯滤波（ImageOnlyTransform）
   - Sharpen 锐化（ImageOnlyTransform）
- [x] 文档（README + docstring）
- [x] 单元测试
- [x] AI Studio 自测（部分公开，有效期三天）：<https://aistudio.baidu.com/studio/project/partial/verify/2586123/9bf6d33c51e34ff1984273b17488dc8b>

以上所有算法均使用批处理方式进行，避免在 Python 中调用低效的 for 循环，其中后三种滤波方式使用 paddle.nn.functional.conv2d 实现，边缘直接使用 pad 0 后卷积，未作 OpenCV 中的那些特殊处理，但非边缘部分处理效果与直接调用 OpenCV 效果一致～